### PR TITLE
Correct onActivityResult handling

### DIFF
--- a/android/src/main/kotlin/com/cingulo/device_unlock/DeviceUnlockManager.kt
+++ b/android/src/main/kotlin/com/cingulo/device_unlock/DeviceUnlockManager.kt
@@ -26,8 +26,9 @@ class DeviceUnlockManager(
                 deviceUnlockCallback?.onFailure()
             }
             deviceUnlockCallback = null
+            return true
         }
-        return true
+        return false
     }
 
     private fun validate(): Pair<String, String>? {


### PR DESCRIPTION
The plugin shouldn't return `true` always, because another plugins won't be able to receive the `onActivityResult` callback.

@felipeespitalher @rserro @rzdgodoy please accept the PR