### PR TITLE
1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,23 @@
-## 0.1.0
+## 1.1.2
 
-- Just testing the publish process, the plugin is not ready yet.
+- [Android] The plugin shouldn't always return true on onActivityResult callback.
 
-## 1.0.0
+## 1.1.1
 
-- Launcing first version
-
-## 1.0.1
-
-- Update descriptions
+- [Android] Fix KeyguardManager
 
 ## 1.1.0
 
 - Simplify exceptions
 
-## 1.1.1
+## 1.0.1
 
-- [Android] Fix KeyguardManager
+- Update descriptions
+
+## 1.0.0
+
+- Launcing first version
+
+## 0.1.0
+
+- Just testing the publish process, the plugin is not ready yet.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_unlock
 description: A Flutter plugin to request the device unlock screen. This plugin offers a simple way to check the user identity using the default device security.
-version: 1.1.1
+version: 1.1.2
 author: Cíngulo <dev@cingulo.com>
 homepage: https://dev.cingulo.com
 repository: https://github.com/cingulo/device_unlock


### PR DESCRIPTION
- [Android] The plugin shouldn't always return true on onActivityResult callback.